### PR TITLE
Added some compile time options.

### DIFF
--- a/Application/Loader/Loader.c
+++ b/Application/Loader/Loader.c
@@ -27,7 +27,9 @@
 //
 // Paths to the driver to try
 //
+#ifndef EFIGUARD_DRIVER_FILENAME
 #define EFIGUARD_DRIVER_FILENAME		L"EfiGuardDxe.efi"
+#endif
 STATIC CHAR16* mDriverPaths[] = {
 	L"\\EFI\\Boot\\" EFIGUARD_DRIVER_FILENAME,
 	L"\\EFI\\" EFIGUARD_DRIVER_FILENAME,

--- a/EfiGuardDxe/util.c
+++ b/EfiGuardDxe/util.c
@@ -16,6 +16,7 @@ STATIC ZydisFormatterFunc DefaultInstructionFormatter;
 
 
 EFI_STATUS
+EFIAPI
 RtlSleep(
 	IN UINTN Milliseconds
 	)

--- a/EfiGuardDxe/util.h
+++ b/EfiGuardDxe/util.h
@@ -28,6 +28,7 @@ RtlSleep(
 // Stalls CPU for N milliseconds.
 //
 EFI_STATUS
+EFIAPI
 RtlStall(
 	IN UINTN Milliseconds
 	);

--- a/EfiGuardPkg.dsc
+++ b/EfiGuardPkg.dsc
@@ -83,6 +83,9 @@
 !if $(EAC_COMPAT_MODE) == 1
   *_*_*_CC_FLAGS = -D EAC_COMPAT_MODE=1
 !endif
+!ifdef $(EFIGUARD_DRIVER_FILENAME)
+  *_*_*_CC_FLAGS = -D EFIGUARD_DRIVER_FILENAME=\"$(EFIGUARD_DRIVER_FILENAME)\"
+!endif
 
   # Source files are UTF-8 without BOM. MSVC will convert other encodings to this without asking, so this is not really a choice
   MSFT:*_*_*_CC_FLAGS = /utf-8

--- a/EfiGuardPkg.dsc
+++ b/EfiGuardPkg.dsc
@@ -77,6 +77,9 @@
 !if $(CONFIGURE_DRIVER) == 1
   *_*_*_CC_FLAGS = -D CONFIGURE_DRIVER=1
 !endif
+!if $(DO_NOT_DISABLE_PATCHGUARD) == 1
+  *_*_*_CC_FLAGS = -D DO_NOT_DISABLE_PATCHGUARD=1
+!endif
 
   # Source files are UTF-8 without BOM. MSVC will convert other encodings to this without asking, so this is not really a choice
   MSFT:*_*_*_CC_FLAGS = /utf-8

--- a/EfiGuardPkg.dsc
+++ b/EfiGuardPkg.dsc
@@ -80,6 +80,9 @@
 !if $(DO_NOT_DISABLE_PATCHGUARD) == 1
   *_*_*_CC_FLAGS = -D DO_NOT_DISABLE_PATCHGUARD=1
 !endif
+!if $(EAC_COMPAT_MODE) == 1
+  *_*_*_CC_FLAGS = -D EAC_COMPAT_MODE=1
+!endif
 
   # Source files are UTF-8 without BOM. MSVC will convert other encodings to this without asking, so this is not really a choice
   MSFT:*_*_*_CC_FLAGS = /utf-8


### PR DESCRIPTION
- leave PG fully intact (may not really useful)
- EasyAntiCheat compat mode (partially disable PG, still possible to enable/disable DSE at runtime)
- set a different driver filename for the loader to search for

Not sure if that may be of any use for anyone. But just in case, here is the PR.