### PR TITLE
Add VeraCrypt support

### DIFF
--- a/EfiGuardDxe/EfiGuardDxe.c
+++ b/EfiGuardDxe/EfiGuardDxe.c
@@ -156,7 +156,7 @@ HookedLoadImage(
 
 	// We only have a filename to go on at this point. We will determine the final 'is this bootmgfw.efi?' status after the image has been loaded
 	CONST BOOLEAN MaybeBootmgfw = ImagePath != NULL
-		? StriStr(ImagePath, L"bootmgfw.efi") != NULL || StriStr(ImagePath, L"bootx64.efi") != NULL
+		? StriStr(ImagePath, L"bootmgfw.efi") != NULL || StriStr(ImagePath, L"Bootmgfw_ms.vc") != NULL || StriStr(ImagePath, L"bootx64.efi") != NULL
 		: FALSE;
 	CONST BOOLEAN IsBoot = (MaybeBootmgfw || (BootPolicy == TRUE && SourceBuffer == NULL));
 


### PR DESCRIPTION
The way VeraCrypt messes with EfiGuard (and, basically, anything else that hooks LoadImage to look for the boot manager) is:

1. Renames bootmgfw.efi to Bootmgfw_ms.vc;
2. Replaces bootmgfw.efi with it's own boot manager (that does decryption);
3. After decryption is done, loads Bootmgfw_ms.vc (original Windows bootloader).

Fix is very simple: **add a contains check for Bootmgfw_ms.vc**.
Tested and WORKS on **Windows 10 Pro 10.0.19045**, **VeraCrypt 1.26.7**.